### PR TITLE
Tracking for invalid media paths

### DIFF
--- a/src/asset_folder_importer.cfg
+++ b/src/asset_folder_importer.cfg
@@ -8,11 +8,10 @@ database_password={postgres-pass}
 start_path=/srv/Multimedia2/Media Production/Assets
 
 #Path where prelude projects live
-prelude_home=/srv/projectfiles/Projects
+prelude_home=/path/to/premiere_projects
 
 #Path where premiere projects live
-#premiere_home=/srv/projectfiles/Projects
-premiere_home=/Volumes/Project_Files_MultiMedia/Projects
+premiere_home=/path/to/premiere_projects
 
 #How to connect to the Vidispine database
 vs_host={vidispine-host}
@@ -31,3 +30,6 @@ vs_import_category=Rushes
 #housekeeping
 #purge system messages after this number of days
 system_message_purge_time = 5
+
+#if this is set, notify Sentry of errors
+sentry_dsn={my-dsn}

--- a/src/asset_folder_importer/database.py
+++ b/src/asset_folder_importer/database.py
@@ -19,7 +19,12 @@ class ArgumentError(StandardError):
 
 
 class AlreadyLinkedError(StandardError):
-    pass
+    def __init__(self, fileid, vsprojectid):
+        self.fileid = fileid
+        self.vsprojectid = vsprojectid
+
+    def __str__(self):
+        return "File with id %s is already linked to project %s" % (self.fileid, self.vsprojectid)
 
 
 class importer_db:
@@ -365,7 +370,7 @@ class importer_db:
         result=cursor.fetchone()
 
         if result[0]>0:
-            raise AlreadyLinkedError("File id %s is already linked to project %s" % (fileid,projectid))
+            raise AlreadyLinkedError(fileid,projectid)
 
         cursor.execute("insert into edit_project_clips (file_ref,project_ref) values (%s,%s)", (fileid,projectid))
 

--- a/src/asset_folder_importer/premiere_get_referenced_media/Exceptions.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/Exceptions.py
@@ -3,3 +3,6 @@ class InvalidDataError(StandardError):
 
 class NoMediaError(StandardError):
     pass
+
+class NotInDatabaseError(StandardError):
+    pass

--- a/src/asset_folder_importer/premiere_get_referenced_media/Exceptions.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/Exceptions.py
@@ -1,0 +1,5 @@
+class InvalidDataError(StandardError):
+    pass
+
+class NoMediaError(StandardError):
+    pass

--- a/src/asset_folder_importer/premiere_get_referenced_media/PremiereProject.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/PremiereProject.py
@@ -1,0 +1,59 @@
+import xml.sax as sax
+import logging
+import shutil
+import tempfile
+import gzip
+from PremiereSAXHandler import PremiereSAXHandler
+from Exceptions import InvalidDataError, NoMediaError
+import os
+
+lg = logging.getLogger(__name__)
+
+
+class PremiereProject(object):
+    def __init__(self):
+        self._parser = sax.make_parser()
+        self.xmltree = None
+        self.filename = None
+        self.isCompressed = False
+        self._sax_handler = PremiereSAXHandler()
+        self._parser.setContentHandler(self._sax_handler)
+
+    def load(self, filename, useTempFile=True):
+
+        tf = None
+        if useTempFile:
+            lg.debug("PremiereProject::load - requested to use temporary file")
+            tf = tempfile.NamedTemporaryFile(suffix="prproj",delete=False)
+            tempname = tf.name
+            lg.debug("PremiereProject::load - temporary file is %s" % tempname)
+            shutil.copy2(filename,tempname)
+            filename = tempname
+
+        lg.debug("PremiereProject::load - loading %s" % filename)
+        try:
+            self.isCompressed = True
+            f = gzip.open(filename, "rb")
+            self._parser.parse(f)
+            f.close()
+        except IOError:  #if gzip doesn't want to read it, then try as a plain file...
+            lg.warning("Open with gzip failed, trying standard file")
+            self.isCompressed = False
+            f = open(filename, "rb")
+            self._parser.parse(f)
+            f.close()
+        if tf is not None:
+            lg.debug("PremiereProject::load - removing temporary file %s" % tf.name)
+            os.unlink(tf.name)
+
+    def getParticulars(self):
+        if self._sax_handler.uuid == "" or self._sax_handler.version == "":
+
+            raise InvalidDataError("no uuid or version in premiere project")
+        return {'uuid': self._sax_handler.uuid, 'version': self._sax_handler.version}
+
+    def getReferencedMedia(self, fullData=False):
+        if len(self._sax_handler.media_references) == 0:
+            raise NoMediaError("Premiere project does not have any media file references")
+        return self._sax_handler.media_references
+

--- a/src/asset_folder_importer/premiere_get_referenced_media/PremiereSAXHandler.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/PremiereSAXHandler.py
@@ -1,0 +1,66 @@
+import xml.sax as sax
+import logging
+import re
+
+
+class PremiereSAXHandler(sax.ContentHandler):
+    """
+    A SAX handler class that stores media references from a premiere project XML
+    """
+    def startDocument(self):
+        self.media_references = []
+        self.render_files = []
+        self.uuid = ""
+        self.version = ""
+        self.logger = logging.getLogger('PremiereSAXHandler')
+        self.logger.setLevel(logging.WARNING)
+        self.tag_tree = []
+        self._buffer = ""
+        self._in_media_ref = False
+        pass
+
+    def startElement(self, name, attrs):
+        #self.logger.debug("startElement got {0} with {1}".format(name,attrs))
+        self.tag_tree.append(name)
+        try:
+            if name == "PremiereData":
+                try:
+                    self.version = int(attrs['Version'])
+                except ValueError:
+                    self.version = attrs['Version']
+            elif name == "RootProjectItem":
+                try:
+                    self.uuid = attrs['ObjectUID']
+                except KeyError:
+                    pass
+            elif name == "ActualMediaFilePath":
+                #pprint(self.tag_tree)
+                if self.tag_tree[-2] == 'Media':
+                    self._in_media_ref = True
+        except KeyError:
+            #pprint((name, attrs.__dict__))
+            #print self.tag_tree[-1]
+            pass
+
+    def endElement(self, name):
+        #self.logger.debug("endElement for {0}".format(name))
+        self.tag_tree.pop()
+        if name == 'ActualMediaFilePath':
+            self.media_references.append(self._buffer)
+            self._buffer = ""
+            self._in_media_ref = False
+
+    def characters(self, content):
+        if self._in_media_ref:
+            #self.logger.debug(content)
+            self._buffer += content
+
+    def endDocument(self):
+        is_preview = re.compile(r'\.PRV/')
+        n=0
+        for ref in self.media_references:
+            if is_preview.search(ref):
+                self.render_files.append(ref)
+                del self.media_references[n]
+            else:
+                n+=1

--- a/src/asset_folder_importer/premiere_get_referenced_media/processor.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/processor.py
@@ -1,0 +1,217 @@
+from asset_folder_importer.database import *
+from asset_folder_importer.premiere_get_referenced_media.PremiereProject import PremiereProject
+from asset_folder_importer.premiere_get_referenced_media.Exceptions import NoMediaError, InvalidDataError
+from gnmvidispine.vs_collection import VSCollection
+from gnmvidispine.vs_item import VSItem
+from gnmvidispine.vidispine_api import *
+import re
+import logging
+
+lg = logging.getLogger(__name__)
+
+
+def id_from_filepath(filepath):
+    """
+    Retrieves the vidispine ID portion of a project name or None if none could be found
+    :param filepath: filepath (full or relative) to check
+    :return: String of the Vidispine ID or None of it could not be found
+    """
+    filename = os.path.basename(filepath)
+    matches = re.search(u'^(.*)\.[^\.]+$', filename)
+    if matches is not None:
+        return matches.group(1)
+    else:
+        return None
+
+
+def partial_path_match(source_path, target_path, limit_len):
+    """
+    Returns True if the source_path and target_path match up to a certain number of segments
+    :param source_path: source path to check
+    :param target_path: target path to check
+    :param limit_len: number of path segments which must match
+    :return: boolean
+    """
+    source_segments = source_path.split(os.path.sep)
+    target_segments = target_path.split(os.path.sep)
+    return do_partial_match(source_segments, target_segments, limit_len)
+
+
+def do_partial_match(source_segments, target_segments, limit_len, start=0):
+    """
+    does the work for partial_path_match
+    :param source_segments: list of path segments
+    :param target_segments: list of path segments
+    :param limit_len: number which must match
+    :param start: number of segment at which to start (default=0)
+    :return: boolean
+    """
+    if len(target_segments) > len(source_segments):
+        n = len(source_segments)
+        target_segments = target_segments[0:n]
+
+    for n in range(start, limit_len):
+        target_path = os.path.sep.join(target_segments[n:])
+        source_path = os.path.sep.join(source_segments[n:])
+        if source_path.endswith('/') and not target_path.endswith('/'):
+            target_path += '/'
+        lg.debug("comparing %s to %s" % (source_path, target_path))
+        if source_path == target_path:
+            return True
+
+
+def find_vsstorage_for(filepath, vs_pathmap, limit_len):
+    """
+    Returns the relevant Vidispine storage for the given filepath or None if none could be found
+    :param filepath: filepath to look up
+    :param vs_pathmap: pathmap within which to go lookup. Get this from gnmvidispine.vs_storage.storage_path_map.
+    :param limit_len: limit of matching path segments within which to consider the match
+    :return: Vidispine ID of storage or None if none could be found
+    """
+    pathsegments = filter(None, filepath.split(os.path.sep))  #filter out null values
+
+    for key, value in vs_pathmap.items():
+        source_segments = filter(None, key.split(os.path.sep))
+        #must start matching at 1, as the first part is /srv on the server and /Volumes on the client
+        if do_partial_match(source_segments, pathsegments, limit_len, start=1):
+            return value
+
+
+def find_item_id_for_path(path):
+    """
+    Gets the Vidispine item ID for the given filepath. Raises VSNotFound if the path does not exist in VS
+    :param path: path to check
+    :return: item ID to which this file is attached.
+    """
+    storage = find_vsstorage_for(path, vs_pathmap,50)
+    fileref = storage.fileForPath(path)
+    return fileref.memberOfItem
+
+
+def remove_path_chunks(filepath, to_remove):
+    """
+    Removes segments from the start of a file path. Raises AttributeError if the file path has less than to_remove segments
+    :param filepath: file path to truncate
+    :param to_remove: number of segments to remove
+    :return: truncated file path
+    """
+    pathsegments = filepath.split(os.path.sep)
+    return os.path.sep.join(pathsegments[to_remove:])
+
+
+def process_premiere_project(filepath, raven_client, db=None, cfg=None):
+    """
+    Main function to process a Premiere project file
+    :param filepath: file path to process
+    :param db: asset importer database object
+    :param cfg: asset importer configuration object
+    :return:
+    """
+    global vs_pathmap
+    lg.debug("---------------------------------")
+    lg.info("Premiere project: %s" % filepath)
+
+    collection_vsid = id_from_filepath(filepath)
+    lg.info("Project's Vidispine ID: %s" % collection_vsid)
+    vsproject = VSCollection(host=cfg.value('vs_host'), port=cfg.value('vs_port'), user=cfg.value('vs_user'),
+                             passwd=cfg.value('vs_password'))
+    vsproject.setName(collection_vsid)  #we don't need the actual metadata so don't bother getting it.
+
+    pp = PremiereProject()
+    try:
+        pp.load(filepath)
+    except Exception as e:
+        lg.error("Unable to read '%s': %s" % (filepath,e.message))
+        lg.error(traceback.format_exc())
+        print "Unable to read '%s': %s" % (filepath,e.message)
+        traceback.print_exc()
+        raven_client.captureException()
+        return (0,0,0)
+
+    lg.debug("determining project details and updating database...")
+    try:
+        projectDetails = pp.getParticulars()
+
+        project_id = db.upsert_edit_project(os.path.dirname(filepath), os.path.basename(filepath),
+                                            projectDetails['uuid'], projectDetails['version'],
+                                            desc="Adobe Premiere Project",
+                                            opens_with="/Applications/Adobe Premiere Pro CC 2014/Adobe Premiere Pro CC 2014.app/Contents/MacOS/Adobe Premiere Pro CC 2014")
+    except ValueError as e:
+        project_id = db.log_project_issue(os.path.dirname(filepath), os.path.basename(filepath), problem="Invalid project file", detail="{0}: {1} {2}".format(e.__class__,str(e),traceback.format_exc()))
+        lg.error("Unable to read project file '{0}' - {1}".format(filepath,str(e)))
+        lg.error(traceback.format_exc())
+        raven_client.captureException()
+        return (0,0,0)
+    except KeyError as e:
+        project_id = db.log_project_issue(os.path.dirname(filepath), os.path.basename(filepath), problem="Invalid project file", detail="{0}: {1} {2}".format(e.__class__,str(e),traceback.format_exc()))
+        db.insert_sysparam("warning","Unable to read project file '{0}' - {1}".format(filepath, str(e)))
+        lg.error("Unable to read project file '{0}' - {1}".format(filepath,str(e)))
+        lg.error(traceback.format_exc())
+        raven_client.captureException()
+        return (0,0,0)
+
+    except InvalidDataError as e:
+        db.insert_sysparam("warning","Corrupted project file: {0} {1}".format(filepath,unicode(e)))
+        raven_client.captureException()
+        return (0,0,0)
+
+    total_files = 0
+    no_vsitem = 0
+    not_in_db = 0
+
+    lg.debug("looking for referenced media....")
+    for filepath in pp.getReferencedMedia():
+        total_files += 1
+        server_path = re.sub(u'^/Volumes', '/srv', filepath).encode('utf-8')
+
+        vsid = db.get_vidispine_id(server_path)
+        # this call will return None if the file is not from an asset folder, e.g. newswire
+        if vsid is None:
+            try:
+                vsid = find_item_id_for_path(server_path)
+                if vsid is None:
+                    lg.error("File {0} is found by Vidispine but has not been imported yet".format(server_path))
+                    continue
+            except VSNotFound:
+                lg.error("File {0} could not be found in either Vidispine or the asset importer database".format(server_path))
+                continue
+
+        item = VSItem(host=cfg.value('vs_host'),port=cfg.value('vs_port'),user=cfg.value('vs_user'),passwd=cfg.value('vs_password'))
+        item.populate(vsid,specificFields=['gnm_asset_category'])
+        try:
+            if item.get('gnm_asset_category').lower() == 'branding':
+                lg.info("File %s is branding, not adding to project" % (filepath, ))
+                if "Internet Downloads" in server_path:
+                    vsproject.set_metadata({'gnm_project_invalid_media_paths': server_path}, mode="add")
+                continue
+        except AttributeError:
+            lg.warning("File %s has no value for gnm_asset_catetory" % (filepath, ))
+
+        lg.debug("Got filepath %s" % filepath)
+        fileid = db.fileId(server_path)
+        if fileid:
+            try:
+                db.link_file_to_edit_project(fileid, project_id)
+                lg.debug("Linked file %s with id %s to project %s" % (filepath, fileid, project_id))
+            except AlreadyLinkedError:
+                lg.info("File %s with id %s is already linked to project %s" % (filepath, fileid, project_id))
+                continue
+        else:
+            not_in_db += 1
+            lg.warning("File %s could not be found in the database" % filepath)
+            continue
+        n = 0
+        found = False
+
+        #using this construct to avoid loading more data from VS than necessary.  We simply check whether the ID exists
+        #in the parent collections list (cached on the item record) without lifting any more info out of VS
+        if vsproject.name in map(lambda x: x.name,item.parent_collections(shouldPopulate=False)):
+            lg.info("File %s is already in project %s" % (filepath,vsproject.name))
+            continue
+
+        vsproject.addToCollection(item=item)    #this call will apparently succeed if the item is already added to said collection, but it won't be added twice.
+
+    lg.info(
+        "Run complete. Out of a total of %d referenced files, %d did not have a Vidispine item and %d were not in the Asset Importer database" % (
+            total_files, no_vsitem, not_in_db))
+    return (total_files, no_vsitem, not_in_db)

--- a/src/asset_folder_importer/tests/test_premiere_processor.py
+++ b/src/asset_folder_importer/tests/test_premiere_processor.py
@@ -1,0 +1,63 @@
+import unittest2
+from mock import MagicMock, patch
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+
+class TestProcessPremiereProject(unittest2.TestCase):
+    class FakeConfig(object):
+        def __init__(self):
+            self.content = {
+                'vs_host': 'host',
+                'vs_port': 8080,
+                'vs_user': 'fred',
+                'vs_passwd': 'smith'
+            }
+
+        def value(self, key):
+            return getattr(self.content,key,None)
+
+    def test_load_correct_collection(self):
+        """
+        process_premiere_project should load VS collection with the right ID given from the project name
+        :return:
+        """
+        from asset_folder_importer.database import importer_db
+        from gnmvidispine.vs_collection import VSCollection
+        mock_database = MagicMock(target=importer_db)
+
+        #with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSCollection') as mock_coll:
+        mock_coll_instance = MagicMock(target=VSCollection)
+
+        with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSCollection', return_value=mock_coll_instance):
+            with patch('asset_folder_importer.premiere_get_referenced_media.processor.PremiereProject') as mock_proj:
+                mock_proj.getReferencedMedia = MagicMock(return_value=['/Volumes/Internet Downloads/WRONG FILE.mov'])
+                from asset_folder_importer.premiere_get_referenced_media.processor import process_premiere_project
+                process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig())
+                mock_coll_instance.setName.assert_called_with("VX-446")
+
+    def test_notify_wrongpath(self):
+        """
+        process_premiere_project should update project record with any non-SAN media paths
+        :return:
+        """
+        from asset_folder_importer.database import importer_db
+        from gnmvidispine.vs_collection import VSCollection
+        from gnmvidispine.vidispine_api import VSNotFound
+        from gnmvidispine.vs_item import VSItem
+        from asset_folder_importer.premiere_get_referenced_media.PremiereProject import PremiereProject
+        mock_database = MagicMock(target=importer_db)
+
+        #with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSCollection') as mock_coll:
+        mock_coll_instance = MagicMock(target=VSCollection)
+        mock_proj_instance = MagicMock(target=PremiereProject)
+        mock_item_instance = MagicMock(target=VSItem)
+        mock_proj_instance.getReferencedMedia = MagicMock(return_value=['/Volumes/Internet Downloads/WRONG FILE.mov'])
+        with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSCollection', return_value=mock_coll_instance) as mock_coll:
+            with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSItem', return_value=mock_item_instance):
+                with patch('asset_folder_importer.premiere_get_referenced_media.processor.PremiereProject', return_value=mock_proj_instance) as mock_proj:
+                    with patch('asset_folder_importer.premiere_get_referenced_media.processor.process_premiere_fileref',side_effect=VSNotFound()):
+                        from asset_folder_importer.premiere_get_referenced_media.processor import process_premiere_project
+
+                        process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig())
+                        mock_coll_instance.set_metadata.assert_called_once_with({'gnm_project_invalid_media_paths': '/Volumes/Internet Downloads/WRONG FILE.mov'},mode="add")

--- a/src/premiere_get_referenced_media.py
+++ b/src/premiere_get_referenced_media.py
@@ -274,9 +274,12 @@ def process_premiere_project(filepath, db=None, cfg=None):
             
         item = VSItem(host=cfg.value('vs_host'),port=cfg.value('vs_port'),user=cfg.value('vs_user'),passwd=cfg.value('vs_password'))
         item.populate(vsid,specificFields=['gnm_asset_category'])
+
         try:
             if item.get('gnm_asset_category').lower() == 'branding':
                 lg.info("File %s is branding, not adding to project" % (filepath, ))
+                if "Internet Downloads" in server_path:
+                    vsproject.set_metadata({'gnm_project_invalid_media_paths': server_path}, mode="add")
                 continue
         except AttributeError:
             lg.warning("File %s has no value for gnm_asset_catetory" % (filepath, ))

--- a/src/setup.py
+++ b/src/setup.py
@@ -10,6 +10,7 @@ setup(name='gnm-assetsweeper',
       packages=['asset_folder_importer',
                 'asset_folder_importer.asset_folder_sweeper',
                 'asset_folder_importer.asset_folder_vsingester',
+                'asset_folder_importer.premiere_get_referenced_media'
                 'asset_folder_importer.fix_unattached_media',
                 'asset_folder_importer.metadata_templates',
                 'asset_folder_importer.pluto',

--- a/src/setup.py
+++ b/src/setup.py
@@ -10,7 +10,7 @@ setup(name='gnm-assetsweeper',
       packages=['asset_folder_importer',
                 'asset_folder_importer.asset_folder_sweeper',
                 'asset_folder_importer.asset_folder_vsingester',
-                'asset_folder_importer.premiere_get_referenced_media'
+                'asset_folder_importer.premiere_get_referenced_media',
                 'asset_folder_importer.fix_unattached_media',
                 'asset_folder_importer.metadata_templates',
                 'asset_folder_importer.pluto',


### PR DESCRIPTION
this PR updates premiere_get_referenced_media to put warnings onto project records when files are found in non-manageable (i.e., non-SAN) locations