### PR TITLE
Fix for premiere_get_referenced_media crash on None asset category REFACTORED

### DIFF
--- a/src/asset_folder_importer/premiere_get_referenced_media/processor.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/processor.py
@@ -119,8 +119,12 @@ def process_premiere_fileref(filepath, server_path, vsproject, db=None, cfg=None
 
     item = VSItem(host=cfg.value('vs_host'),port=cfg.value('vs_port'),user=cfg.value('vs_user'),passwd=cfg.value('vs_password'))
     item.populate(vsid,specificFields=['gnm_asset_category'])
-    if item.get('gnm_asset_category').lower() == 'branding':
-        lg.info("File %s is branding, not adding to project" % (filepath, ))
+    if item.get('gnm_asset_category') is not None:
+        if item.get('gnm_asset_category').lower() == 'branding':
+            lg.info("File %s is branding, not adding to project" % (filepath, ))
+            return item
+    else:
+        lg.info("gnm_asset_category field empty so continuing")
 
     lg.debug("Got filepath %s" % filepath)
     fileid = db.fileId(server_path)


### PR DESCRIPTION
refactored version of https://github.com/guardian/assetsweeper/pull/27