### PR TITLE
DA Skip More Preview Files

### DIFF
--- a/src/asset_folder_importer/asset_folder_sweeper/ignore_list.py
+++ b/src/asset_folder_importer/asset_folder_sweeper/ignore_list.py
@@ -22,7 +22,8 @@ class IgnoreList(object):
         '\.pek$',
         '_synctemp', #this is created by PluralEyes
         '\.cfa$',
-        '\.aep Logs'
+        '\.aep Logs',
+        'Adobe Premiere Pro Video Previews'
     ]
 
     def __init__(self):

--- a/src/asset_folder_importer/tests/test_ignore_list.py
+++ b/src/asset_folder_importer/tests/test_ignore_list.py
@@ -16,6 +16,7 @@ class TestIgnoreList(unittest.TestCase):
         self.assertTrue(test_list.should_ignore("/path/to/some/assets",".hiddenfile"))
         self.assertTrue(test_list.should_ignore("/path/to/some/assets","Mic01_1.pek"))
         self.assertTrue(test_list.should_ignore("/path/to/some/assets","something.aep 48000.cfa"))
+        self.assertTrue(test_list.should_ignore("/path/to/some/Adobe Premiere Pro Video Previews/subpath","yadayadayada.xxx"))
 
     def test_should_not_match(self):
         from asset_folder_importer.asset_folder_sweeper.ignore_list import IgnoreList


### PR DESCRIPTION
Simple change adding 'Adobe Premiere Pro Video Previews' to an ignore list and a test which checks it works.

@fredex42 