### PR TITLE
DA Fix Unicode Error

### DIFF
--- a/src/asset_folder_importer/premiere_get_referenced_media/processor.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/processor.py
@@ -216,17 +216,26 @@ def process_premiere_project(filepath, raven_client, vs_pathmap=None, db=None, c
 
             vsproject.addToCollection(item=item)    #this call will apparently succeed if the item is already added to said collection, but it won't be added twice.
         except VSNotFound:
-            lg.error("File {0} could not be found in either Vidispine or the asset importer database".format(server_path))
+            try:
+                lg.error("File {0} could not be found in either Vidispine or the asset importer database".format(server_path))
+            except UnicodeEncodeError:
+                lg.error("File {0} could not be found in either Vidispine or the asset importer database".format(server_path.encode('utf-8')))
             if "Internet Downloads" in filepath:
                 #note - this could raise a 400 exception IF there is a conflict with something else trying to add info to the same field
                 vsproject.set_metadata({'gnm_project_invalid_media_paths': filepath}, mode="add")
             continue
         except NotInDatabaseError:
             not_in_db += 1
-            lg.warning("File %s could not be found in the database" % filepath)
+            try:
+                lg.warning("File %s could not be found in the database" % filepath)
+            except UnicodeEncodeError:
+                lg.warning("File %s could not be found in the database" % filepath.encode('utf-8'))
             continue
         except AlreadyLinkedError as e:
-            lg.info("File %s with id %s is already linked to project %s" % (filepath, e.fileid, e.vsprojectid))
+            try:
+                lg.info("File %s with id %s is already linked to project %s" % (filepath, e.fileid, e.vsprojectid))
+            except UnicodeEncodeError:
+                lg.info("File %s with id %s is already linked to project %s" % (filepath.encode('utf-8'), e.fileid, e.vsprojectid))
             continue
 
     lg.info(

--- a/src/asset_folder_importer/premiere_get_referenced_media/processor.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/processor.py
@@ -198,8 +198,14 @@ def process_premiere_project(filepath, raven_client, vs_pathmap=None, db=None, c
     lg.debug("looking for referenced media....")
     for filepath in pp.getReferencedMedia():
         total_files += 1
-        lg.debug("Looking up {0}".format(filepath))
-        server_path = re.sub(u'^/Volumes', '/srv', filepath).encode('utf-8')
+        try:
+            lg.debug("Looking up {0}".format(filepath))
+        except UnicodeEncodeError:
+            lg.debug("Looking up {0}".format(filepath.encode('utf-8')))
+        try:
+            server_path = re.sub(u'^/Volumes', '/srv', filepath).encode('utf-8')
+        except UnicodeDecodeError:
+            server_path = re.sub(u'^/Volumes', '/srv', filepath.decode('utf-8'))
         try:
             item=process_premiere_fileref(filepath, server_path, project_id, vs_pathmap=vs_pathmap, db=db, cfg=cfg)
             #using this construct to avoid loading more data from VS than necessary.  We simply check whether the ID exists

--- a/src/asset_folder_importer/tests/test_premiere_processor.py
+++ b/src/asset_folder_importer/tests/test_premiere_processor.py
@@ -64,6 +64,10 @@ class TestProcessPremiereProject(unittest2.TestCase):
                         mock_coll_instance.set_metadata.assert_called_once_with({'gnm_project_invalid_media_paths': '/Volumes/Internet Downloads/WRONG FILE.mov'},mode="add")
 
     def test_filepath_unicode(self):
+        """
+        process_premiere_project should be able to cope with a non-ASCII character in the file path
+        :return:
+        """
         from asset_folder_importer.database import importer_db
         from gnmvidispine.vs_collection import VSCollection
         from gnmvidispine.vidispine_api import VSNotFound
@@ -82,5 +86,30 @@ class TestProcessPremiereProject(unittest2.TestCase):
                     with patch('asset_folder_importer.premiere_get_referenced_media.processor.process_premiere_fileref',side_effect=VSNotFound()):
                         from asset_folder_importer.premiere_get_referenced_media.processor import process_premiere_project
 
-                        process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig())
-                        mock_proj_instance.addToCollection.assert_called_once_with(item=mock_item_instance)
+                        self.assertEqual(process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig()), (1, 0, 0))
+
+    def test_filepath_ascii(self):
+        """
+        process_premiere_project should be able to cope with a file path with only ASCII characters
+        :return:
+        """
+        from asset_folder_importer.database import importer_db
+        from gnmvidispine.vs_collection import VSCollection
+        from gnmvidispine.vidispine_api import VSNotFound
+        from gnmvidispine.vs_item import VSItem
+        from asset_folder_importer.premiere_get_referenced_media.PremiereProject import PremiereProject
+        mock_database = MagicMock(target=importer_db)
+
+        #with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSCollection') as mock_coll:
+        mock_coll_instance = MagicMock(target=VSCollection)
+        mock_proj_instance = MagicMock(target=PremiereProject)
+        mock_item_instance = MagicMock(target=VSItem)
+        mock_proj_instance.getReferencedMedia = MagicMock(return_value=['/Volumes/Multimedia2/Media Production/Assets/ASCII.mp3'])
+        with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSCollection', return_value=mock_coll_instance) as mock_coll:
+            with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSItem', return_value=mock_item_instance):
+                with patch('asset_folder_importer.premiere_get_referenced_media.processor.PremiereProject', return_value=mock_proj_instance) as mock_proj:
+                    with patch('asset_folder_importer.premiere_get_referenced_media.processor.process_premiere_fileref',side_effect=VSNotFound()):
+                        from asset_folder_importer.premiere_get_referenced_media.processor import process_premiere_project
+
+                        self.assertEqual(process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig()), (1, 0, 0))
+


### PR DESCRIPTION
This fixes various Unicode decode and encode errors that happen if the file path has non-ASCII characters in it.

There are also two tests. One tests if the function can cope with a non-ASCII character in the file path, the other checks if the function can cope with a file path containing only ASCII characters.

@fredex42 