### PR TITLE
DA Record Errors

### DIFF
--- a/src/asset_folder_importer/premiere_get_referenced_media/processor.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/processor.py
@@ -88,6 +88,7 @@ def find_item_id_for_path(path, vs_pathmap):
         fileref = storage.fileForPath(path)
     except HTTPError as e:
         lg.error(str(e))
+        raise
     return fileref.memberOfItem
 
 

--- a/src/asset_folder_importer/premiere_get_referenced_media/processor.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/processor.py
@@ -84,7 +84,10 @@ def find_item_id_for_path(path, vs_pathmap):
     :return: item ID to which this file is attached.
     """
     storage = find_vsstorage_for(path, vs_pathmap,50)
-    fileref = storage.fileForPath(path)
+    try:
+        fileref = storage.fileForPath(path)
+    except HTTPError as e:
+        lg.error(str(e))
     return fileref.memberOfItem
 
 


### PR DESCRIPTION
Logs data about HTTPError exceptions if they occur when storage.fileForPath(path) is called.

@fredex42 