### PR TITLE
DA Invalid Media Paths Value Write Now Preservers More Than One Path

### DIFF
--- a/src/asset_folder_importer.cfg
+++ b/src/asset_folder_importer.cfg
@@ -36,3 +36,6 @@ sentry_dsn={my-dsn}
 
 #the name of the elasticsearch index that portal uses
 portal_index_name = portal
+
+#comma separated list of strings that will cause the path to be counted as invalid
+invalid_path_strings=Internet Downloads,Editorial Users

--- a/src/asset_folder_importer/premiere_get_referenced_media/processor.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/processor.py
@@ -225,7 +225,13 @@ def process_premiere_project(filepath, raven_client, vs_pathmap=None, db=None, c
                 lg.error("File {0} could not be found in either Vidispine or the asset importer database".format(server_path))
             except UnicodeEncodeError:
                 lg.error("File {0} could not be found in either Vidispine or the asset importer database".format(server_path.encode('utf-8')))
-            if ("Internet Downloads" in filepath) or ("Editorial Users" in filepath):
+
+            invalid_path_data = ['Internet Downloads', 'Editorial Users']
+
+            if cfg.value('invalid_path_strings'):
+                invalid_path_data = cfg.value('invalid_path_strings').split(',')
+
+            if any(x in filepath for x in invalid_path_data):
                 filepath_doctored = filepath.replace(',', '')
                 #note - this could raise a 400 exception IF there is a conflict with something else trying to add info to the same field
                 vsprojectmetadata = VSCollection(host=cfg.value('vs_host'), port=cfg.value('vs_port'), user=cfg.value('vs_user'),

--- a/src/asset_folder_importer/tests/test_premiere_processor.py
+++ b/src/asset_folder_importer/tests/test_premiere_processor.py
@@ -54,6 +54,7 @@ class TestProcessPremiereProject(unittest2.TestCase):
         mock_proj_instance = MagicMock(target=PremiereProject)
         mock_item_instance = MagicMock(target=VSItem)
         mock_proj_instance.getReferencedMedia = MagicMock(return_value=['/Volumes/Internet Downloads/WRONG FILE.mov'])
+        mock_coll_instance.get = MagicMock(return_value=None)
         with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSCollection', return_value=mock_coll_instance) as mock_coll:
             with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSItem', return_value=mock_item_instance):
                 with patch('asset_folder_importer.premiere_get_referenced_media.processor.PremiereProject', return_value=mock_proj_instance) as mock_proj:
@@ -61,7 +62,7 @@ class TestProcessPremiereProject(unittest2.TestCase):
                         from asset_folder_importer.premiere_get_referenced_media.processor import process_premiere_project
 
                         process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig())
-                        mock_coll_instance.set_metadata.assert_called_once_with({'gnm_project_invalid_media_paths': '/Volumes/Internet Downloads/WRONG FILE.mov'},mode="add")
+                        mock_coll_instance.set_metadata.assert_called_with({'gnm_project_invalid_media_paths': '/Volumes/Internet Downloads/WRONG FILE.mov'},mode="add")
 
     def test_filepath_unicode(self):
         """


### PR DESCRIPTION
System now preservers more than one invalid media path if present in the Premiere Pro file.

System will also now treat any paths including 'Editorial Users' as invalid.

Tested on a local virtual machine.

@fredex42 