### PR TITLE
DA Fix Writing of Non-ASCII Path Data

### DIFF
--- a/src/asset_folder_importer/premiere_get_referenced_media/processor.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/processor.py
@@ -243,7 +243,7 @@ def process_premiere_project(filepath, raven_client, vs_pathmap=None, db=None, c
                 else:
                     paths_list = current_value_of_field.split(",")
                     if filepath_doctored not in paths_list:
-                        vsproject.set_metadata({'gnm_project_invalid_media_paths': '{0},{1}'.format(current_value_of_field,filepath_doctored)}, mode="add")
+                        vsproject.set_metadata({'gnm_project_invalid_media_paths': '{0},{1}'.format(current_value_of_field.encode('utf-8'),filepath_doctored.encode('utf-8'))}, mode="add")
             continue
         except NotInDatabaseError:
             not_in_db += 1


### PR DESCRIPTION
Along with some fixes in GNM Vidispine, this fixes writing of non-ASCII path data.

![image](https://user-images.githubusercontent.com/10620802/41246742-ea25f392-6da3-11e8-9243-0c0b9a51f600.png)

Tested on a machine running Mac OS 10.11.

@fredex42 