### PR TITLE
DA Only Change Metadata When Needed

### DIFF
--- a/src/asset_folder_importer/premiere_get_referenced_media/processor.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/processor.py
@@ -155,8 +155,10 @@ def process_premiere_project(filepath, raven_client, vs_pathmap=None, db=None, c
     lg.info("Project's Vidispine ID: %s" % collection_vsid)
     vsproject = VSCollection(host=cfg.value('vs_host'), port=cfg.value('vs_port'), user=cfg.value('vs_user'),
                              passwd=cfg.value('vs_password'))
-    vsproject.setName(collection_vsid)  #we don't need the actual metadata so don't bother getting it.
-    vsproject.set_metadata({'gnm_project_invalid_media_paths': ''}, mode="add")
+    vsproject.populate(collection_vsid)
+    current_value_of_field = vsproject.get('gnm_project_invalid_media_paths')
+    if current_value_of_field is not None:
+        vsproject.set_metadata({'gnm_project_invalid_media_paths': ''}, mode="add")
 
     pp = PremiereProject()
     try:

--- a/src/asset_folder_importer/premiere_get_referenced_media/processor.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/processor.py
@@ -140,6 +140,15 @@ def process_premiere_fileref(filepath, server_path, vsproject, vs_pathmap=None, 
     return item
 
 
+def update_invalid_media_paths(vsproject, invalid_media_paths):
+    lg.debug("update_invalid_media_paths called with: {0}".format(invalid_media_paths))
+    current_value_of_field = vsproject.get('gnm_project_invalid_media_paths', allowArray=True)
+    lg.debug("update_invalid_media_paths.current_value_of_field: {0}".format(current_value_of_field))
+    lg.debug("update_invalid_media_paths.invalid_media_paths: {0}".format(invalid_media_paths))
+    if invalid_media_paths != current_value_of_field:
+        vsproject.set_metadata({'gnm_project_invalid_media_paths': invalid_media_paths}, mode="add")
+
+
 def process_premiere_project(filepath, raven_client, vs_pathmap=None, db=None, cfg=None):
     """
     Main function to process a Premiere project file
@@ -156,9 +165,6 @@ def process_premiere_project(filepath, raven_client, vs_pathmap=None, db=None, c
     vsproject = VSCollection(host=cfg.value('vs_host'), port=cfg.value('vs_port'), user=cfg.value('vs_user'),
                              passwd=cfg.value('vs_password'))
     vsproject.populate(collection_vsid)
-    current_value_of_field = vsproject.get('gnm_project_invalid_media_paths')
-    if current_value_of_field is not None:
-        vsproject.set_metadata({'gnm_project_invalid_media_paths': ''}, mode="add")
 
     pp = PremiereProject()
     try:
@@ -201,6 +207,7 @@ def process_premiere_project(filepath, raven_client, vs_pathmap=None, db=None, c
     total_files = 0
     no_vsitem = 0
     not_in_db = 0
+    invalid_media_paths = []
 
     lg.debug("looking for referenced media....")
     for filepath in pp.getReferencedMedia():
@@ -236,16 +243,7 @@ def process_premiere_project(filepath, raven_client, vs_pathmap=None, db=None, c
             if any(x in filepath for x in invalid_path_data):
                 filepath_doctored = filepath.replace(',', '')
                 #note - this could raise a 400 exception IF there is a conflict with something else trying to add info to the same field
-                vsprojectmetadata = VSCollection(host=cfg.value('vs_host'), port=cfg.value('vs_port'), user=cfg.value('vs_user'),
-                                         passwd=cfg.value('vs_password'))
-                vsprojectmetadata.populate(collection_vsid)
-                current_value_of_field = vsprojectmetadata.get('gnm_project_invalid_media_paths')
-                if current_value_of_field == None:
-                    vsproject.set_metadata({'gnm_project_invalid_media_paths': filepath_doctored}, mode="add")
-                else:
-                    paths_list = current_value_of_field.split(",")
-                    if filepath_doctored not in paths_list:
-                        vsproject.set_metadata({'gnm_project_invalid_media_paths': '{0},{1}'.format(current_value_of_field.encode('utf-8'),filepath_doctored.encode('utf-8'))}, mode="add")
+                invalid_media_paths.append(filepath_doctored)
             continue
         except NotInDatabaseError:
             not_in_db += 1
@@ -260,6 +258,8 @@ def process_premiere_project(filepath, raven_client, vs_pathmap=None, db=None, c
             except UnicodeEncodeError:
                 lg.info("File %s with id %s is already linked to project %s" % (filepath.encode('utf-8'), e.fileid, e.vsprojectid))
             continue
+
+    update_invalid_media_paths(vsproject, invalid_media_paths)
 
     lg.info(
         "Run complete. Out of a total of %d referenced files, %d did not have a Vidispine item and %d were not in the Asset Importer database" % (

--- a/src/asset_folder_importer/tests/test_premiere_processor.py
+++ b/src/asset_folder_importer/tests/test_premiere_processor.py
@@ -35,7 +35,7 @@ class TestProcessPremiereProject(unittest2.TestCase):
                 mock_proj.getReferencedMedia = MagicMock(return_value=['/Volumes/Internet Downloads/WRONG FILE.mov'])
                 from asset_folder_importer.premiere_get_referenced_media.processor import process_premiere_project
                 process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig())
-                mock_coll_instance.setName.assert_called_with("VX-446")
+                mock_coll_instance.populate.assert_called_with("VX-446")
 
     def test_notify_wrongpath(self):
         """

--- a/src/asset_folder_importer/tests/test_premiere_processor.py
+++ b/src/asset_folder_importer/tests/test_premiere_processor.py
@@ -65,7 +65,10 @@ class TestProcessPremiereProject(unittest2.TestCase):
                         mock_coll_instance.set_metadata.assert_called_with({'gnm_project_invalid_media_paths': ['/Volumes/Internet Downloads/WRONG FILE.mov']},mode="add")
 
     def test_no_values(self):
-
+        """
+        update_invalid_media_paths should be able to cope with when the old value is empty and the new value is empty
+        :return:
+        """
         from asset_folder_importer.database import importer_db
         from gnmvidispine.vs_collection import VSCollection
         from gnmvidispine.vidispine_api import VSNotFound
@@ -85,7 +88,143 @@ class TestProcessPremiereProject(unittest2.TestCase):
                         from asset_folder_importer.premiere_get_referenced_media.processor import process_premiere_project
 
                         process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig())
+                        mock_coll_instance.get.assert_called()
                         mock_coll_instance.set_metadata.assert_not_called()
+
+    def test_no_current_value_add_a_list(self):
+        """
+        update_invalid_media_paths should be able to cope with when the old value is empty and the new is a list
+        :return:
+        """
+        from asset_folder_importer.database import importer_db
+        from gnmvidispine.vs_collection import VSCollection
+        from gnmvidispine.vidispine_api import VSNotFound
+        from gnmvidispine.vs_item import VSItem
+        from asset_folder_importer.premiere_get_referenced_media.PremiereProject import PremiereProject
+        mock_database = MagicMock(target=importer_db)
+
+        mock_coll_instance = MagicMock(target=VSCollection)
+        mock_proj_instance = MagicMock(target=PremiereProject)
+        mock_item_instance = MagicMock(target=VSItem)
+        mock_proj_instance.getReferencedMedia = MagicMock(return_value=['/Volumes/Internet Downloads/WRONG FILE.mov'])
+        mock_coll_instance.get = MagicMock(return_value=[])
+        with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSCollection', return_value=mock_coll_instance) as mock_coll:
+            with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSItem', return_value=mock_item_instance):
+                with patch('asset_folder_importer.premiere_get_referenced_media.processor.PremiereProject', return_value=mock_proj_instance) as mock_proj:
+                    with patch('asset_folder_importer.premiere_get_referenced_media.processor.process_premiere_fileref',side_effect=VSNotFound()):
+                        from asset_folder_importer.premiere_get_referenced_media.processor import process_premiere_project
+
+                        process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig())
+                        mock_coll_instance.get.assert_called()
+                        mock_coll_instance.set_metadata.assert_called_with({'gnm_project_invalid_media_paths': ['/Volumes/Internet Downloads/WRONG FILE.mov']},mode="add")
+
+    def test_current_value_is_a_list_replace_with_no_value(self):
+        """
+        update_invalid_media_paths should be able to cope with when the old value is a list and the new value is empty
+        :return:
+        """
+        from asset_folder_importer.database import importer_db
+        from gnmvidispine.vs_collection import VSCollection
+        from gnmvidispine.vidispine_api import VSNotFound
+        from gnmvidispine.vs_item import VSItem
+        from asset_folder_importer.premiere_get_referenced_media.PremiereProject import PremiereProject
+        mock_database = MagicMock(target=importer_db)
+
+        mock_coll_instance = MagicMock(target=VSCollection)
+        mock_proj_instance = MagicMock(target=PremiereProject)
+        mock_item_instance = MagicMock(target=VSItem)
+        mock_proj_instance.getReferencedMedia = MagicMock(return_value=[])
+        mock_coll_instance.get = MagicMock(return_value=['/Volumes/Internet Downloads/WRONG FILE.mov'])
+        with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSCollection', return_value=mock_coll_instance) as mock_coll:
+            with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSItem', return_value=mock_item_instance):
+                with patch('asset_folder_importer.premiere_get_referenced_media.processor.PremiereProject', return_value=mock_proj_instance) as mock_proj:
+                    with patch('asset_folder_importer.premiere_get_referenced_media.processor.process_premiere_fileref',side_effect=VSNotFound()):
+                        from asset_folder_importer.premiere_get_referenced_media.processor import process_premiere_project
+
+                        process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig())
+                        mock_coll_instance.get.assert_called()
+                        mock_coll_instance.set_metadata.assert_called_with({'gnm_project_invalid_media_paths': []},mode="add")
+
+    def test_same_lists(self):
+        """
+        update_invalid_media_paths should be able to cope with when both values are the same list
+        :return:
+        """
+        from asset_folder_importer.database import importer_db
+        from gnmvidispine.vs_collection import VSCollection
+        from gnmvidispine.vidispine_api import VSNotFound
+        from gnmvidispine.vs_item import VSItem
+        from asset_folder_importer.premiere_get_referenced_media.PremiereProject import PremiereProject
+        mock_database = MagicMock(target=importer_db)
+
+        mock_coll_instance = MagicMock(target=VSCollection)
+        mock_proj_instance = MagicMock(target=PremiereProject)
+        mock_item_instance = MagicMock(target=VSItem)
+        mock_proj_instance.getReferencedMedia = MagicMock(return_value=['/Volumes/Internet Downloads/WRONG FILE.mov'])
+        mock_coll_instance.get = MagicMock(return_value=['/Volumes/Internet Downloads/WRONG FILE.mov'])
+        with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSCollection', return_value=mock_coll_instance) as mock_coll:
+            with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSItem', return_value=mock_item_instance):
+                with patch('asset_folder_importer.premiere_get_referenced_media.processor.PremiereProject', return_value=mock_proj_instance) as mock_proj:
+                    with patch('asset_folder_importer.premiere_get_referenced_media.processor.process_premiere_fileref',side_effect=VSNotFound()):
+                        from asset_folder_importer.premiere_get_referenced_media.processor import process_premiere_project
+
+                        process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig())
+                        mock_coll_instance.get.assert_called()
+                        mock_coll_instance.set_metadata.assert_not_called()
+
+    def test_longer_list(self):
+        """
+        update_invalid_media_paths should be able to cope with when the old value is a list and the new value is a list including the same data but longer
+        :return:
+        """
+        from asset_folder_importer.database import importer_db
+        from gnmvidispine.vs_collection import VSCollection
+        from gnmvidispine.vidispine_api import VSNotFound
+        from gnmvidispine.vs_item import VSItem
+        from asset_folder_importer.premiere_get_referenced_media.PremiereProject import PremiereProject
+        mock_database = MagicMock(target=importer_db)
+
+        mock_coll_instance = MagicMock(target=VSCollection)
+        mock_proj_instance = MagicMock(target=PremiereProject)
+        mock_item_instance = MagicMock(target=VSItem)
+        mock_proj_instance.getReferencedMedia = MagicMock(return_value=['/Volumes/Internet Downloads/WRONG FILE.mov'])
+        mock_coll_instance.get = MagicMock(return_value=['/Volumes/Internet Downloads/WRONG FILE.mov', '/Volumes/Internet Downloads/ANOTHER WRONG FILE.mov'])
+        with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSCollection', return_value=mock_coll_instance) as mock_coll:
+            with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSItem', return_value=mock_item_instance):
+                with patch('asset_folder_importer.premiere_get_referenced_media.processor.PremiereProject', return_value=mock_proj_instance) as mock_proj:
+                    with patch('asset_folder_importer.premiere_get_referenced_media.processor.process_premiere_fileref',side_effect=VSNotFound()):
+                        from asset_folder_importer.premiere_get_referenced_media.processor import process_premiere_project
+
+                        process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig())
+                        mock_coll_instance.get.assert_called()
+                        mock_coll_instance.set_metadata.assert_called_with({'gnm_project_invalid_media_paths': ['/Volumes/Internet Downloads/WRONG FILE.mov']},mode="add")
+
+    def test_shorter_list(self):
+        """
+        update_invalid_media_paths should be able to cope with when the old value is a list and the new value is a list including some of the same data but shorter
+        :return:
+        """
+        from asset_folder_importer.database import importer_db
+        from gnmvidispine.vs_collection import VSCollection
+        from gnmvidispine.vidispine_api import VSNotFound
+        from gnmvidispine.vs_item import VSItem
+        from asset_folder_importer.premiere_get_referenced_media.PremiereProject import PremiereProject
+        mock_database = MagicMock(target=importer_db)
+
+        mock_coll_instance = MagicMock(target=VSCollection)
+        mock_proj_instance = MagicMock(target=PremiereProject)
+        mock_item_instance = MagicMock(target=VSItem)
+        mock_proj_instance.getReferencedMedia = MagicMock(return_value=['/Volumes/Internet Downloads/WRONG FILE.mov', '/Volumes/Internet Downloads/ANOTHER WRONG FILE.mov'])
+        mock_coll_instance.get = MagicMock(return_value=['/Volumes/Internet Downloads/WRONG FILE.mov'])
+        with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSCollection', return_value=mock_coll_instance) as mock_coll:
+            with patch('asset_folder_importer.premiere_get_referenced_media.processor.VSItem', return_value=mock_item_instance):
+                with patch('asset_folder_importer.premiere_get_referenced_media.processor.PremiereProject', return_value=mock_proj_instance) as mock_proj:
+                    with patch('asset_folder_importer.premiere_get_referenced_media.processor.process_premiere_fileref',side_effect=VSNotFound()):
+                        from asset_folder_importer.premiere_get_referenced_media.processor import process_premiere_project
+
+                        process_premiere_project("/fakeproject/VX-446.prproj", None, db=mock_database, cfg=self.FakeConfig())
+                        mock_coll_instance.get.assert_called()
+                        mock_coll_instance.set_metadata.assert_called_with({'gnm_project_invalid_media_paths': ['/Volumes/Internet Downloads/WRONG FILE.mov', '/Volumes/Internet Downloads/ANOTHER WRONG FILE.mov']},mode="add")
 
     def test_filepath_unicode(self):
         """


### PR DESCRIPTION
Loads the metadata of the collection so the 'gnm_project_invalid_media_paths' field can be checked to see if it is not set to None before changing the value.

Tested on a machine running Mac OS 10.11.

@fredex42 