### PR TITLE
New scripts to find "flushable" unimported media

### DIFF
--- a/src/asset_folder_vsingester.py
+++ b/src/asset_folder_vsingester.py
@@ -5,16 +5,8 @@ __version__ = 'asset_folder_vsingester $Rev: 273 $ $LastChangedDate: 2015-07-28 
 __scriptname__ = 'asset_folder_vsingester'
 
 #this also requires python-setuptools to be installed
-from gnmvidispine.vs_storage import VSStorage
-from asset_folder_importer.database import importer_db
 from asset_folder_importer.config import configfile
-from pprint import pprint
 from optparse import OptionParser
-import traceback
-import os
-import re
-import time
-import logging
 from Queue import Queue
 from asset_folder_importer.asset_folder_vsingester.exceptions import *
 from asset_folder_importer.asset_folder_vsingester.importer_thread import *

--- a/src/find_flushable_unimported_media.py
+++ b/src/find_flushable_unimported_media.py
@@ -111,7 +111,7 @@ total_notfound_sizes = 0
 assetfolder_not_found = []
 counted_files = 0
 
-fp_toflush = open("to_flush.ls","w")
+fp_toflush = open("to_flush.lst","w")
 fp_noassetfolder = open("no_asset_folder.lst","w")
 
 try:
@@ -137,7 +137,7 @@ try:
         if projectinfo['gnm_project_status'] == 'Completed':
             fullpath = os.path.join(unimported_file['filepath'],unimported_file['filename'])
             total_completed_sizes += (unimported_file['size']/1024**3)
-            fp_toflush.write("{0},{1}".format(projectinfo['collection_id'], fullpath))
+            fp_toflush.write("{0},{1}\n".format(projectinfo['collection_id'], fullpath))
 
         logger.info("{0} files: total completed: {1}Gb, total asset folder not found: {2}Gb, total of everything: {3}Gb".format(counted_files, total_completed_sizes, total_notfound_sizes, total_all_sizes))
 

--- a/src/find_flushable_unimported_media.py
+++ b/src/find_flushable_unimported_media.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python
+
+__version__ = "find_flushable_unimported_media v1"
+
+import logging
+from optparse import OptionParser
+from asset_folder_importer.config import configfile
+from asset_folder_importer.database import importer_db
+import urllib
+import requests
+import os.path
+import time
+
+# Configurable parameters
+LOGFORMAT = '%(asctime)-15s - %(levelname)s - Thread %(thread)s - %(funcName)s: %(message)s'
+main_log_level = logging.ERROR
+logfile = None
+#logfile = "/var/log/plutoscripts/find_flushable_unimported_media.log"
+#End configurable parameters
+
+
+class AssetFolderCache(object):
+    def __init__(self, cfg):
+        self._cfg = cfg
+        self._cache = {}
+
+    def get_pluto_info(self, asset_folder_path):
+        url = "http://{0}:{1}/gnm_asset_folder/lookup?path={2}".format(cfg.value('pluto_host'), cfg.value('pluto_port'), urllib.quote(asset_folder_path, safe=''))
+        logger.debug(url)
+
+        while True:
+            response = requests.get(url, auth=(cfg.value('vs_user'), cfg.value('vs_password')))
+            if response.status_code==200:
+                return response.json()
+            elif response.status_code==404:
+                return None
+            elif response.status_code>=400 and response.status_code<500:
+                logger.error("Error {0} accessing {1}: {2}".format(response.status_code, url, response.text))
+                raise StandardError("Could not look up")
+            else:
+                logger.warning("Error {0} accessing {1}. Retrying in 10s".format(response.status_code, url))
+                time.sleep(10)
+
+    def get_project_info(self, projectid):
+        url = "http://{0}:{1}/project/{2}/api".format(cfg.value('pluto_host'), cfg.value('pluto_port'), projectid)
+        logger.debug(url)
+
+        while True:
+            response = requests.get(url, auth=(cfg.value('vs_user'), cfg.value('vs_password')), headers={'Accept': 'application/json'})
+            if response.status_code==200:
+                return response.json()
+            elif response.status_code>=400 and response.status_code<500:
+                logger.error("Error {0} accessing {1}: {2}".format(response.status_code, url, response.text))
+                raise StandardError("Could not look up")
+            else:
+                logger.warning("Error {0} accessing {1}. Retrying in 10s".format(response.status_code, url))
+                time.sleep(10)
+
+    def lookup(self, complete_path):
+        """
+        returns a dict of project information about the attached asset folder, from the local cache if possible
+        :param complete_path:
+        :return:
+        """
+        pathparts = complete_path.split("/")
+        asset_folder_path = "/".join(pathparts[0:8])
+
+        if asset_folder_path in self._cache:
+            return self._cache[asset_folder_path]
+
+        pluto_info = self.get_pluto_info(asset_folder_path)
+        if pluto_info is None:
+            return None
+        logger.debug(pluto_info)
+        project_info = self.get_project_info(pluto_info['project'])
+        logger.debug(project_info)
+
+        self._cache[asset_folder_path] = project_info
+        return project_info
+
+#START MAIN
+#Step one. Commandline args.
+parser = OptionParser()
+parser.add_option("-c","--config", dest="configfile", help="import configuration from this file")
+(options, args) = parser.parse_args()
+
+if options.configfile:
+    cfg=configfile(options.configfile)
+else:
+    cfg=configfile("/etc/asset_folder_importer.cfg")
+
+if logfile is not None:
+    logging.basicConfig(filename=logfile, format=LOGFORMAT, level=main_log_level)
+else:
+    logging.basicConfig(format=LOGFORMAT, level=main_log_level)
+
+logger = logging.getLogger("__main__")
+logger.level = logging.INFO
+
+logger.info("-----------------------------------------------------------\n\n")
+logger.info("Connecting to database on %s" % cfg.value('database_host', noraise=True))
+
+db = importer_db(__version__,hostname=cfg.value('database_host'),port=cfg.value('database_port'),username=cfg.value('database_user'),password=cfg.value('database_password'))
+
+ac = AssetFolderCache(cfg)
+
+total_completed_sizes = 0
+total_all_sizes = 0
+assetfolder_not_found = []
+counted_files = 0
+
+for unimported_file in db.filesForVSID(vsid=None):
+    counted_files+=1
+    #logger.debug("{0}".format(os.path.join(unimported_file['filepath'],unimported_file['filename'])))
+
+    projectinfo = ac.lookup(unimported_file['filepath'])
+    if projectinfo is None:
+        fullpath = os.path.join(unimported_file['filepath'],unimported_file['filename'])
+        logger.debug("{0}: could not find asset folder".format(fullpath))
+        assetfolder_not_found.append(fullpath)
+        continue
+
+    if projectinfo['gnm_project_status'] == 'Completed':
+        total_completed_sizes += (unimported_file['size']/1024**3)
+    total_all_sizes += (unimported_file['size']/1024**3)
+    logger.info("{0} files: total completed: {1}Gb, total of everything: {2}Gb".format(counted_files, total_completed_sizes, total_all_sizes))
+
+if len(assetfolder_not_found)>0:
+    logger.warning("{0} files had unrecognized asset folders:".format(len(assetfolder_not_found)))
+    for path in assetfolder_not_found:
+        logger.warning("\t{0}".format(path))
+
+logger.info("All done")

--- a/src/setup.py
+++ b/src/setup.py
@@ -23,7 +23,7 @@ setup(name='gnm-assetsweeper',
       scripts=['asset_folder_sweeper.py','asset_folder_verify_files.py',
                'asset_folder_vsingester.py','asset_permissions.pl',
                'prelude_importer.py','premiere_get_referenced_media.py',
-               'fix_unattached_media.py','vs_resync_deleted.py'],
+               'fix_unattached_media.py','vs_resync_deleted.py', 'find_flushable_unimported_media.py'],
       data_files=[
           ('/etc',['asset_folder_importer.cfg','footage_providers.yml']),
           ('/etc/sudoers.d',['asset_folder_sudo'])


### PR DESCRIPTION
`find_flushable_unimported_media` uses the asset importer database and cross-references to Pluto to find media that is either a) in an asset folder belonging to a project that is already "completed" or b) in a non-recognised path and outputs text-based lists of these.

The lists can then be processed by https://github.com/fredex42/upload_flush_list_mt to safely push the items out to temporary archive for re-integration later