### PR TITLE
Fix for Items Not Getting Project Links

### DIFF
--- a/src/asset_folder_importer/pluto/assetfolder.py
+++ b/src/asset_folder_importer/pluto/assetfolder.py
@@ -22,7 +22,7 @@ class AssetFolderLocator(object):
         self._port=port
         self._user=user
         self._passwd=passwd
-        self._http = http_client if http_client is not None else httplib.HTTPConnection(self._host, self._port)
+        self._http = http_client if http_client is not None else self.new_connection(scheme=scheme)
         self._logger=logger if logger is not None else logging.getLogger(__name__)
 
     def new_connection(self,scheme="http"):
@@ -46,8 +46,7 @@ class AssetFolderLocator(object):
             path=urllib.quote(path,'')
         )
         self._logger.debug("retrieving info from {0}".format(url))
-        if self.http_client is None:
-            self._http = self.new_connection(scheme=self._scheme)
+        self._http.connect()
         self._http.request("GET",url,headers=headers)
         response = self._http.getresponse()
         raw_content = response.read() #must always read or you get ResponseNotReady when re-using

--- a/src/asset_folder_importer/pluto/assetfolder.py
+++ b/src/asset_folder_importer/pluto/assetfolder.py
@@ -46,7 +46,8 @@ class AssetFolderLocator(object):
             path=urllib.quote(path,'')
         )
         self._logger.debug("retrieving info from {0}".format(url))
-        self._http = self.new_connection(scheme=self._scheme)
+        if self.http_client is None:
+            self._http = self.new_connection(scheme=self._scheme)
         self._http.request("GET",url,headers=headers)
         response = self._http.getresponse()
         raw_content = response.read() #must always read or you get ResponseNotReady when re-using

--- a/src/asset_folder_importer/pluto/assetfolder.py
+++ b/src/asset_folder_importer/pluto/assetfolder.py
@@ -46,7 +46,7 @@ class AssetFolderLocator(object):
             path=urllib.quote(path,'')
         )
         self._logger.debug("retrieving info from {0}".format(url))
-        
+        self._http = self.new_connection(scheme=self._scheme)
         self._http.request("GET",url,headers=headers)
         response = self._http.getresponse()
         raw_content = response.read() #must always read or you get ResponseNotReady when re-using

--- a/src/asset_folder_importer/tests/test_assetfolder.py
+++ b/src/asset_folder_importer/tests/test_assetfolder.py
@@ -25,6 +25,7 @@ class TestAssetfolder(unittest.TestCase):
         
         conn.getresponse = mock.MagicMock(return_value=self.FakeResponse(okstatus,200))
         conn.request = mock.MagicMock()
+        conn.connect = mock.MagicMock()
         
         l = AssetFolderLocator(passwd='fake_password',http_client=conn)
         
@@ -40,6 +41,7 @@ class TestAssetfolder(unittest.TestCase):
         
         conn.getresponse = mock.MagicMock(return_value=self.FakeResponse(errstatus, 404))
         conn.request = mock.MagicMock()
+        conn.connect = mock.MagicMock()
         
         l = AssetFolderLocator(passwd='fake_password', http_client=conn)
         
@@ -53,6 +55,7 @@ class TestAssetfolder(unittest.TestCase):
         
         conn.getresponse = mock.MagicMock(return_value=self.FakeResponse(errstatus, 500))
         conn.request = mock.MagicMock()
+        conn.connect = mock.MagicMock()
         
         l = AssetFolderLocator(passwd='fake_password', http_client=conn)
         

--- a/src/asset_folder_importer/tests/test_importer_thread.py
+++ b/src/asset_folder_importer/tests/test_importer_thread.py
@@ -238,7 +238,8 @@ class TestImporterThread(unittest.TestCase):
         mock_fileref.ctime = datetime(2018,01,04,15,30,00)
 
         i=ImporterThread(None,None,self.FakeConfig({
-            'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
+            'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
+            'pluto_scheme': 'http'
         }),dbconn=mock_db)
 
         result = i.render_xml(mock_fileref,None,None,None,None,None,"/path/to/my/test/file")
@@ -264,7 +265,8 @@ class TestImporterThread(unittest.TestCase):
         mock_fileref.ctime = datetime(2018,01,04,15,30,00)
 
         i=ImporterThread(None,None,self.FakeConfig({
-            'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
+            'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
+            'pluto_scheme': 'http'
         }),dbconn=mock_db)
 
         result = i.render_xml(mock_fileref,None,None,None,None,None,"/path/to/my/test/file",media_category="Branding")
@@ -320,7 +322,8 @@ class TestImporterThread(unittest.TestCase):
         }
 
         i=ImporterThread(None,None,self.FakeConfig({
-            'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
+            'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
+            'pluto_scheme': 'http'
         }),dbconn=mock_db)
         i.st = mock_storage
         i.ask_pluto_for_projectid = MagicMock(return_value=None) #there will be no record of this as an asset folder

--- a/src/asset_folder_importer/tests/test_importer_thread.py
+++ b/src/asset_folder_importer/tests/test_importer_thread.py
@@ -126,7 +126,8 @@ class TestImporterThread(unittest.TestCase):
             logger.setLevel(logging.ERROR)
             i = ImporterThread(None, None,
                                self.FakeConfig({
-                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
+                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
+                                   'pluto_scheme': 'http'
                                }), dbconn=db)
             
             mock_connection.side_effect = lambda h, c: self.FakeConnection(json.dumps({'status': 'notfound'}), 404)
@@ -157,7 +158,8 @@ class TestImporterThread(unittest.TestCase):
             logger.setLevel(logging.ERROR)
             i = ImporterThread(None, None,
                                self.FakeConfig({
-                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
+                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
+                                   'pluto_scheme': 'http'
                                }), dbconn=db)
 
             i.st = mockstorage
@@ -196,7 +198,8 @@ class TestImporterThread(unittest.TestCase):
             mock_vsfile.importToItem = mock.MagicMock(return_value=fake_job)
 
             i=ImporterThread(None,None,self.FakeConfig({
-                'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
+                'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
+                'pluto_scheme': 'http'
             }),dbconn=db,import_timeout=4)  #set importer timeout to 4s
             start_time = time()
             with self.assertRaises(ImportStalled):

--- a/src/asset_folder_importer/tests/test_importer_thread.py
+++ b/src/asset_folder_importer/tests/test_importer_thread.py
@@ -105,8 +105,7 @@ class TestImporterThread(unittest.TestCase):
             logger.setLevel(logging.ERROR)
             i = ImporterThread(None, None,
                                self.FakeConfig({
-                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
-                                   'pluto_scheme': 'http'
+                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
                                }), dbconn=db)
             
             mock_connection.side_effect = lambda h,c: self.FakeConnection(json.dumps({'status': 'notfound'}),404)
@@ -126,8 +125,7 @@ class TestImporterThread(unittest.TestCase):
             logger.setLevel(logging.ERROR)
             i = ImporterThread(None, None,
                                self.FakeConfig({
-                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
-                                   'pluto_scheme': 'http'
+                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
                                }), dbconn=db)
             
             mock_connection.side_effect = lambda h, c: self.FakeConnection(json.dumps({'status': 'notfound'}), 404)
@@ -158,8 +156,7 @@ class TestImporterThread(unittest.TestCase):
             logger.setLevel(logging.ERROR)
             i = ImporterThread(None, None,
                                self.FakeConfig({
-                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
-                                   'pluto_scheme': 'http'
+                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
                                }), dbconn=db)
 
             i.st = mockstorage
@@ -198,8 +195,7 @@ class TestImporterThread(unittest.TestCase):
             mock_vsfile.importToItem = mock.MagicMock(return_value=fake_job)
 
             i=ImporterThread(None,None,self.FakeConfig({
-                'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
-                'pluto_scheme': 'http'
+                'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
             }),dbconn=db,import_timeout=4)  #set importer timeout to 4s
             start_time = time()
             with self.assertRaises(ImportStalled):
@@ -238,8 +234,7 @@ class TestImporterThread(unittest.TestCase):
         mock_fileref.ctime = datetime(2018,01,04,15,30,00)
 
         i=ImporterThread(None,None,self.FakeConfig({
-            'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
-            'pluto_scheme': 'http'
+            'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
         }),dbconn=mock_db)
 
         result = i.render_xml(mock_fileref,None,None,None,None,None,"/path/to/my/test/file")
@@ -265,8 +260,7 @@ class TestImporterThread(unittest.TestCase):
         mock_fileref.ctime = datetime(2018,01,04,15,30,00)
 
         i=ImporterThread(None,None,self.FakeConfig({
-            'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
-            'pluto_scheme': 'http'
+            'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
         }),dbconn=mock_db)
 
         result = i.render_xml(mock_fileref,None,None,None,None,None,"/path/to/my/test/file",media_category="Branding")
@@ -322,8 +316,7 @@ class TestImporterThread(unittest.TestCase):
         }
 
         i=ImporterThread(None,None,self.FakeConfig({
-            'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
-            'pluto_scheme': 'http'
+            'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
         }),dbconn=mock_db)
         i.st = mock_storage
         i.ask_pluto_for_projectid = MagicMock(return_value=None) #there will be no record of this as an asset folder

--- a/src/asset_folder_importer/tests/test_importer_thread.py
+++ b/src/asset_folder_importer/tests/test_importer_thread.py
@@ -105,7 +105,8 @@ class TestImporterThread(unittest.TestCase):
             logger.setLevel(logging.ERROR)
             i = ImporterThread(None, None,
                                self.FakeConfig({
-                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
+                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
+                                   'pluto_scheme': 'http'
                                }), dbconn=db)
             
             mock_connection.side_effect = lambda h,c: self.FakeConnection(json.dumps({'status': 'notfound'}),404)

--- a/src/asset_folder_importer/tests/test_importer_thread.py
+++ b/src/asset_folder_importer/tests/test_importer_thread.py
@@ -91,6 +91,9 @@ class TestImporterThread(unittest.TestCase):
             url = urllib.unquote(url)
             if url.endswith('/path/to/my/assetfolder'):
                 self.jackpot=True
+
+        def connect(self):
+            return mock.MagicMock()
         
     def test_find_invalid_projectid(self):
         from asset_folder_importer.asset_folder_vsingester.importer_thread import ImporterThread
@@ -105,7 +108,8 @@ class TestImporterThread(unittest.TestCase):
             logger.setLevel(logging.ERROR)
             i = ImporterThread(None, None,
                                self.FakeConfig({
-                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
+                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
+                                   'pluto_scheme': 'http'
                                }), dbconn=db)
             
             mock_connection.side_effect = lambda h,c: self.FakeConnection(json.dumps({'status': 'notfound'}),404)
@@ -125,7 +129,8 @@ class TestImporterThread(unittest.TestCase):
             logger.setLevel(logging.ERROR)
             i = ImporterThread(None, None,
                                self.FakeConfig({
-                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir)
+                                   'footage_providers_config': '{0}/../../footage_providers.yml'.format(self.mydir),
+                                   'pluto_scheme': 'http'
                                }), dbconn=db)
             
             mock_connection.side_effect = lambda h, c: self.FakeConnection(json.dumps({'status': 'notfound'}), 404)


### PR DESCRIPTION
The new_connection method is now actually used when an HTTP client is not set. A new connection is made before each attempt at access.

These changes fix a problem with items not getting linked to projects on import.

Tested on the live system.

@fredex42  