### PR TITLE
Fix for Issue with 'message' Artibute on Exception Objects

### DIFF
--- a/src/asset_folder_importer/asset_folder_sweeper/find_files.py
+++ b/src/asset_folder_importer/asset_folder_sweeper/find_files.py
@@ -15,7 +15,7 @@ def check_mime(fullpath,db):
     try:
         (mt, encoding) = mimetypes.guess_type(fullpath, strict=False)
     except Exception as e:
-        db.insert_sysparam("warning", e.message)
+        db.insert_sysparam("warning", e)
 
     if mt is None or mt == 'None':
         mt = posix_get_mime(fullpath, db)

--- a/src/asset_folder_importer/asset_folder_vsingester/importer_thread.py
+++ b/src/asset_folder_importer/asset_folder_vsingester/importer_thread.py
@@ -219,8 +219,8 @@ class ImporterThread(threading.Thread):
                 return True
             except Exception as e:
                 self.db.insert_sysparam("warning", "Unable to add %s to collection %s: %s" % (
-                    vsfile.memberOfItem, cubaseref['project_id'], e.message))
-                self.logger.warning("Warning: %s" % e.message)
+                    vsfile.memberOfItem, cubaseref['project_id'], e))
+                self.logger.warning("Warning: %s" % e)
                 self.db.commit()
         else:
             #otherwise, ask Pluto's gnm_asset_folder plugin to look up the file path for us
@@ -266,14 +266,14 @@ class ImporterThread(threading.Thread):
                 self.logger.warning(traceback.format_exc())
                 self.db.insert_sysparam("warning", msgstring)
             except VSNotFound as e:
-                msgstring = "WARNING: File %s was not found: %s" % (filepath, e.message)
+                msgstring = "WARNING: File %s was not found: %s" % (filepath, e)
                 self.logger.warning(msgstring)
                 self.logger.warning(traceback.format_exc())
                 self.db.insert_sysparam("warning", msgstring)
                 # exit(1)
             except HTTPError as e:
                 msgstring = "WARNING: HTTP error communicating with Vidispine attempting to import %s: %s" % (
-                filepath, e.message)
+                filepath, e)
                 self.logger.warning(msgstring)
                 self.logger.warning(traceback.format_exc())
                 self.db.insert_sysparam("warning", msgstring)
@@ -573,5 +573,5 @@ class ImporterThread(threading.Thread):
                         vsfile.memberOfItem.importSidecar(metafile)
                         return True
                 except VSNotFound as e:
-                    self.logger.warning("Unable to find sidecar '%s': %s" % (metafile, e.message))
+                    self.logger.warning("Unable to find sidecar '%s': %s" % (metafile, e))
         return False

--- a/src/asset_folder_importer/database.py
+++ b/src/asset_folder_importer/database.py
@@ -64,7 +64,7 @@ class importer_db:
             cursor.execute(sqlcmd)
             self.conn.commit()
         except psycopg2.ProgrammingError as e:
-            logging.warning("Warning: %s" % e.message)
+            logging.warning("Warning: %s" % e)
             self.conn.rollback()
 
     def __del__(self):

--- a/src/asset_folder_importer/premiere_get_referenced_media/processor.py
+++ b/src/asset_folder_importer/premiere_get_referenced_media/processor.py
@@ -167,9 +167,9 @@ def process_premiere_project(filepath, raven_client, vs_pathmap=None, db=None, c
     try:
         pp.load(filepath)
     except Exception as e:
-        lg.error("Unable to read '%s': %s" % (filepath,e.message))
+        lg.error("Unable to read '%s': %s" % (filepath,e))
         lg.error(traceback.format_exc())
-        print("Unable to read '%s': %s" % (filepath,e.message))
+        print("Unable to read '%s': %s" % (filepath,e))
         traceback.print_exc()
         raven_client.captureException()
         return (0,0,0)

--- a/src/asset_folder_sweeper.py
+++ b/src/asset_folder_sweeper.py
@@ -128,7 +128,7 @@ try:
     db.commit()
 except Exception as e:
     db.insert_sysparam("exit","error")
-    db.insert_sysparam("error",e.message)
+    db.insert_sysparam("error",e)
     db.insert_sysparam("traceback",traceback.format_exc())
     logging.error(traceback.format_exc())
     db.commit()

--- a/src/asset_folder_verify_files.py
+++ b/src/asset_folder_verify_files.py
@@ -111,6 +111,6 @@ except Exception as e:
     if update_vs_pool is not None:
         update_vs_pool.safe_terminate()
     db.insert_sysparam("exit","error")
-    db.insert_sysparam("error",e.message)
+    db.insert_sysparam("error",e)
     db.insert_sysparam("traceback",traceback.format_exc())
     db.end_run(status="error")

--- a/src/asset_folder_vsingester.py
+++ b/src/asset_folder_vsingester.py
@@ -164,10 +164,10 @@ try:
     db.insert_sysparam("exit","success")
 except Exception as e:
     logging.error("An error occurred:")
-    logging.error(str(e.__class__) + ": " + e.message)
+    logging.error(str(e.__class__) + ": " + e)
     logging.error(traceback.format_exc())
 
-    msgstring="{0}: {1}".format(str(e.__class__),e.message)
+    msgstring="{0}: {1}".format(str(e.__class__),e)
     db.cleanuperror()
     db.insert_sysparam("exit","error")
     db.insert_sysparam("errormsg",msgstring)

--- a/src/prelude_importer.py
+++ b/src/prelude_importer.py
@@ -80,7 +80,7 @@ try:
             except NotPreludeProjectException as e:
                 msg = "WARNING: {name} is not a Prelude project: {error}".format(
                     name=os.path.join(dirpath,name),
-                    error=e.message
+                    error=e
                 )
                 db.insert_sysparam("warning",msg)
                 db.commit()


### PR DESCRIPTION
Under Python 3, exception objects do not have the attribute 'message'. These changes remove the references to 'message'.

Tested on the dev. system.

@fredex42