### PR TITLE
Fix for auth Object Not Being a String Under Python 3

### DIFF
--- a/src/asset_folder_importer/pluto/assetfolder.py
+++ b/src/asset_folder_importer/pluto/assetfolder.py
@@ -3,7 +3,6 @@ import urllib.request, urllib.parse, urllib.error
 import logging
 import base64
 import json
-from gnmvidispine.vidispine_api import always_string
 
 logger = logging.getLogger(__name__)
 
@@ -34,7 +33,7 @@ class AssetFolderLocator(object):
 
     def find_assetfolder(self, path):
         authstring = "{0}:{1}".format(self._user, self._passwd)
-        auth = always_string(base64.b64encode(authstring.encode("UTF-8")))
+        auth = base64.b64encode(authstring.encode("UTF-8")).decode("UTF-8")
 
         headers = {
             'Authorization': "Basic %s" % auth,

--- a/src/asset_folder_importer/pluto/assetfolder.py
+++ b/src/asset_folder_importer/pluto/assetfolder.py
@@ -3,6 +3,7 @@ import urllib.request, urllib.parse, urllib.error
 import logging
 import base64
 import json
+from gnmvidispine.vidispine_api import always_string
 
 logger = logging.getLogger(__name__)
 
@@ -33,7 +34,7 @@ class AssetFolderLocator(object):
 
     def find_assetfolder(self, path):
         authstring = "{0}:{1}".format(self._user, self._passwd)
-        auth = base64.b64encode(authstring.encode("UTF-8"))
+        auth = always_string(base64.b64encode(authstring.encode("UTF-8")))
 
         headers = {
             'Authorization': "Basic %s" % auth,


### PR DESCRIPTION
Uses the always_string method to force the auth object into being a string so it works under Python 3.

Tested on the dev. system.

@fredex42 