### PR TITLE
Fatal Error on Failed Connection to Portal

### DIFF
--- a/src/asset_folder_importer/asset_folder_vsingester/exceptions.py
+++ b/src/asset_folder_importer/asset_folder_vsingester/exceptions.py
@@ -19,7 +19,3 @@ class VSFileInconsistencyError(Exception):
     Raised if we get a 503 error from trying to create a file entity in Vidispine.
     """
     pass
-
-
-class PortalHTTPError(Exception):
-    pass

--- a/src/asset_folder_importer/asset_folder_vsingester/exceptions.py
+++ b/src/asset_folder_importer/asset_folder_vsingester/exceptions.py
@@ -19,3 +19,7 @@ class VSFileInconsistencyError(Exception):
     Raised if we get a 503 error from trying to create a file entity in Vidispine.
     """
     pass
+
+
+class PortalHTTPError(Exception):
+    pass

--- a/src/asset_folder_importer/asset_folder_vsingester/importer_thread.py
+++ b/src/asset_folder_importer/asset_folder_vsingester/importer_thread.py
@@ -281,7 +281,7 @@ class ImporterThread(threading.Thread):
             except FileOnIgnoreList:
                 self.ignored += 1
             except SweeperHTTPError as e:
-                msgstring = "WARNING: HTTP error communicating with Vidispine attempting to import %s: %s" % (
+                msgstring = "WARNING: HTTP error communicating with Portal attempting to import %s: %s" % (
                     filepath, e)
                 self.logger.warning(msgstring)
                 self.logger.warning(traceback.format_exc())

--- a/src/asset_folder_importer/asset_folder_vsingester/importer_thread.py
+++ b/src/asset_folder_importer/asset_folder_vsingester/importer_thread.py
@@ -193,6 +193,9 @@ class ImporterThread(threading.Thread):
                     return None #we've run out of path to check
                 project_id = l.find_assetfolder(test_path)
                 return project_id
+            except HTTPError:
+                self.logger.critical("Connection error when attempting to access Portal. Bailing out.")
+                quit()
             except ProjectNotFound:
                 n-=1
             except IndexError:  #we've run out of path segments

--- a/src/asset_folder_importer/asset_folder_vsingester/importer_thread.py
+++ b/src/asset_folder_importer/asset_folder_vsingester/importer_thread.py
@@ -238,7 +238,6 @@ class ImporterThread(threading.Thread):
         return False
     
     def run(self):
-        from asset_folder_importer.pluto.assetfolder import HTTPError
         self.logger.info("In importer_thread::run...")
         while True:
             try:

--- a/src/asset_folder_importer/asset_folder_vsingester/importer_thread.py
+++ b/src/asset_folder_importer/asset_folder_vsingester/importer_thread.py
@@ -175,7 +175,7 @@ class ImporterThread(threading.Thread):
         return stdout
         
     def ask_pluto_for_projectid(self, filepath):
-        from asset_folder_importer.pluto.assetfolder import AssetFolderLocator, ProjectNotFound
+        from asset_folder_importer.pluto.assetfolder import AssetFolderLocator, ProjectNotFound, HTTPError
         l = AssetFolderLocator(scheme=self.cfg.value('pluto_scheme',default="http"), host=self.cfg.value('pluto_host'), port=self.cfg.value('pluto_port'),
                                 user=self.cfg.value('vs_user'), passwd=self.cfg.value('vs_password'))
         

--- a/src/asset_folder_importer/asset_folder_vsingester/importer_thread.py
+++ b/src/asset_folder_importer/asset_folder_vsingester/importer_thread.py
@@ -281,12 +281,13 @@ class ImporterThread(threading.Thread):
             except FileOnIgnoreList:
                 self.ignored += 1
             except SweeperHTTPError as e:
-                msgstring = "WARNING: HTTP error communicating with Portal attempting to import %s: %s" % (
+                msgstring = "ERROR: HTTP error communicating with Portal attempting to import %s: %s" % (
                     filepath, e)
-                self.logger.warning(msgstring)
-                self.logger.warning(traceback.format_exc())
-                self.db.insert_sysparam("warning", msgstring)
+                self.logger.error(msgstring)
+                self.logger.error(traceback.format_exc())
+                self.db.insert_sysparam("error", msgstring)
                 self.portal_error = True
+                break
             except Exception as e:
                 msgstring = "WARNING: error {0} occurred: {1}".format(e.__class__, e)
                 self.logger.warning(msgstring)
@@ -426,6 +427,8 @@ class ImporterThread(threading.Thread):
                 attempts += 1
 
         project_from_pluto = self.ask_pluto_for_projectid(os.path.join(fileref['filepath'], fileref['filename']))
+        if project_from_pluto is not None:
+            logging.info("Found project id. {0} for item at {1}".format(project_from_pluto, os.path.join(fileref['filepath'], fileref['filename'])))
         
         if vsfile.memberOfItem is not None:
             self.logger.info("Found file %s in Vidispine at file id %s, item id %s" % (

--- a/src/asset_folder_importer/pluto/assetfolder.py
+++ b/src/asset_folder_importer/pluto/assetfolder.py
@@ -6,7 +6,7 @@ import json
 
 logger = logging.getLogger(__name__)
 
-class HTTPError(Exception):
+class SweeperHTTPError(Exception):
     def __init__(self, url, responseobject):
         self.response = responseobject
         self.url = url
@@ -58,7 +58,7 @@ class AssetFolderLocator(object):
         
         if response.status<200 or response.status>299:
             logger.warning("Could not find asset folder: server returned {0} with body {1}".format(response.status, raw_content))
-            raise HTTPError(url, response)
+            raise SweeperHTTPError(url, response)
         
         content = json.loads(raw_content)
         

--- a/src/asset_folder_importer/pluto/assetfolder.py
+++ b/src/asset_folder_importer/pluto/assetfolder.py
@@ -7,9 +7,8 @@ import json
 logger = logging.getLogger(__name__)
 
 class SweeperHTTPError(Exception):
-    def __init__(self, url, responseobject):
-        self.response = responseobject
-        self.url = url
+    pass
+
 
 class ProjectNotFound(Exception):
     pass
@@ -58,7 +57,7 @@ class AssetFolderLocator(object):
         
         if response.status<200 or response.status>299:
             logger.warning("Could not find asset folder: server returned {0} with body {1}".format(response.status, raw_content))
-            raise SweeperHTTPError(url, response)
+            raise SweeperHTTPError
         
         content = json.loads(raw_content)
         

--- a/src/asset_folder_importer/tests/test_assetfolder.py
+++ b/src/asset_folder_importer/tests/test_assetfolder.py
@@ -48,7 +48,7 @@ class TestAssetfolder(unittest.TestCase):
         self.assertRaises(ProjectNotFound,l.find_assetfolder,'/path/to/my/asset_folder')
  
     def test_locator_error(self):
-        from asset_folder_importer.pluto.assetfolder import AssetFolderLocator, HTTPError
+        from asset_folder_importer.pluto.assetfolder import AssetFolderLocator, SweeperHTTPError
         
         conn = http.client.HTTPConnection('localhost', 8080)
         errstatus = json.dumps({"status": "error", "error": "some trace"})
@@ -59,7 +59,7 @@ class TestAssetfolder(unittest.TestCase):
         
         l = AssetFolderLocator(passwd='fake_password', http_client=conn)
         
-        self.assertRaises(HTTPError,l.find_assetfolder,'/path/to/my/asset_folder')
+        self.assertRaises(SweeperHTTPError,l.find_assetfolder,'/path/to/my/asset_folder')
             
         # self.assertEqual(ex.exception.response.status, 500)
         # self.assertEqual(ex.exception.url, "http://localhost:80/gnm_asset_folder/lookup?path=%2Fpath%2Fto%2Fmy%2Fasset_folder")

--- a/src/asset_folder_vsingester.py
+++ b/src/asset_folder_vsingester.py
@@ -92,6 +92,9 @@ def innerMainFunc(cfg,db,limit, keeplist):
 
     for t in threads:
         t.join()
+        if t.portal_error is True:
+            logging.critical("Error accessing Portal. Bailing out.")
+            raise PortalHTTPError
         if t.isAlive():
             logging.warning("Thread {0} did not terminate properly".format(t.get_ident()))
 

--- a/src/asset_folder_vsingester.py
+++ b/src/asset_folder_vsingester.py
@@ -42,10 +42,13 @@ def file_has_any_extension(filename, extensionlist):
 
 
 def test_portal_connection(filepath, cfg):
-    from asset_folder_importer.pluto.assetfolder import AssetFolderLocator
+    from asset_folder_importer.pluto.assetfolder import AssetFolderLocator, ProjectNotFound
     tester = AssetFolderLocator(scheme=cfg.value('pluto_scheme',default="http"), host=cfg.value('pluto_host'), port=cfg.value('pluto_port'),
                            user=cfg.value('vs_user'), passwd=cfg.value('vs_password'))
-    tester.find_assetfolder(filepath)
+    try:
+        tester.find_assetfolder(filepath)
+    except ProjectNotFound:
+        pass
     return None
 
 

--- a/src/asset_folder_vsingester.py
+++ b/src/asset_folder_vsingester.py
@@ -90,17 +90,22 @@ def innerMainFunc(cfg,db,limit, keeplist):
     for t in threads:
         input_queue.put((None,None,None))
 
+    portal_problem = False
+
     for t in threads:
         t.join()
         if t.portal_error is True:
-            logging.critical("Error accessing Portal. Bailing out.")
-            raise PortalHTTPError
+            portal_problem = True
         if t.isAlive():
             logging.warning("Thread {0} did not terminate properly".format(t.get_ident()))
 
         found += t.found
         withItems += t.withItems
         imported += t.imported
+
+    if portal_problem:
+        logging.critical("Error accessing Portal. Bailing out.")
+        raise PortalHTTPError
 
     db.insert_sysparam("without_vsid",n)
     db.insert_sysparam("found_in_vidispine",found)

--- a/src/asset_folder_vsingester.py
+++ b/src/asset_folder_vsingester.py
@@ -42,6 +42,12 @@ def file_has_any_extension(filename, extensionlist):
 
 
 def test_portal_connection(filepath, cfg):
+    """
+    Returns None if the Portal connection works. Raises SweeperHTTPError if no connection could be established.
+    :param filepath: The path to test
+    :param cfg: Configuration data for use connecting to Portal
+    :return: None
+    """
     from asset_folder_importer.pluto.assetfolder import AssetFolderLocator, ProjectNotFound
     tester = AssetFolderLocator(scheme=cfg.value('pluto_scheme',default="http"), host=cfg.value('pluto_host'), port=cfg.value('pluto_port'),
                            user=cfg.value('vs_user'), passwd=cfg.value('vs_password'))
@@ -54,11 +60,7 @@ def test_portal_connection(filepath, cfg):
 
 #This function is the main program, but is contained here to make it easier to catch exceptions
 def innerMainFunc(cfg,db,limit, keeplist):
-    try:
-        test_portal_connection('/start/up/test.mxf', cfg)
-    except SweeperHTTPError:
-        logging.critical("Error accessing Portal. Bailing out.")
-        raise PortalHTTPError
+    test_portal_connection('/start/up/test.mxf', cfg)
     storageid=cfg.value('vs_masters_storage')
     logging.info("Connecting to storage with ID %s" % storageid)
     st=VSStorage(host=cfg.value('vs_host'),port=cfg.value('vs_port'),user=cfg.value('vs_user'),passwd=cfg.value('vs_password'))
@@ -123,7 +125,7 @@ def innerMainFunc(cfg,db,limit, keeplist):
 
     if portal_problem:
         logging.critical("Error accessing Portal. Bailing out.")
-        raise PortalHTTPError
+        raise SweeperHTTPError
 
     db.insert_sysparam("without_vsid",n)
     db.insert_sysparam("found_in_vidispine",found)

--- a/src/asset_folder_vsingester.py
+++ b/src/asset_folder_vsingester.py
@@ -167,7 +167,7 @@ try:
     db.insert_sysparam("exit","success")
 except Exception as e:
     logging.error("An error occurred:")
-    logging.error(str(e.__class__) + ": " + e)
+    logging.error(str(e.__class__) + ": " + str(e))
     logging.error(traceback.format_exc())
 
     msgstring="{0}: {1}".format(str(e.__class__),e)


### PR DESCRIPTION
A fatal error is now raised when a connection can not be made to Portal at the start of the main function and before an import attempt is made in the import threads.

A critical error is logged and the database updated in both cases.

Tested on the dev. system.

@fredex42 