### PR TITLE
Require httplib2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ future==0.18.2
 PyYAML==5.1
 python-dateutil==2.6.1
 dataclasses==0.7
+httplib2==0.17.0


### PR DESCRIPTION
Require httplib2 to fix 'getty' error seen in the log. The library is required by the getty.py file.

@fredex42


